### PR TITLE
Changing url in test for the new urls

### DIFF
--- a/testing/testapp/mock/tests/models.py
+++ b/testing/testapp/mock/tests/models.py
@@ -256,7 +256,7 @@ class BasicModelTest(TestCase):
 
     def test_url(self):
         self.assertEquals(
-            '/knowledge/questions/{0}/{1}/'.format(
+            '/knowledge/articles/{0}/{1}/'.format(
                 self.question.id,
                 slugify(self.question.title)),
             self.question.get_absolute_url()


### PR DESCRIPTION
Changing the static url in one test preventing it from failing after
updating with new urls.